### PR TITLE
Bump python from 3.9-slim to 3.12-slim

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Use an official Python runtime as a parent image
-FROM python:3.9-slim
+FROM python:3.12-slim
 
 # Set the working directory in the container
 WORKDIR /app


### PR DESCRIPTION
Bumps python from 3.9-slim to 3.12-slim.

---
updated-dependencies:
- dependency-name: python dependency-type: direct:production ...